### PR TITLE
Update prereqcheck.sh

### DIFF
--- a/Azure-ARM/prereqcheck.sh
+++ b/Azure-ARM/prereqcheck.sh
@@ -159,7 +159,7 @@ fi
 #If updating AAD, make sure you have Application Administrator role
 if [ "$UPDATEAAD" = "Yes" ]; then
 	echo "Checking Application Administrator Role"
-	appDevRoleId=$(az rest --method get --url https://graph.microsoft.com/v1.0/directoryRoles/ | jq -r '.value[] | select(.displayName | contains("Application Administrator")).id')
+	appDevRoleId=$(az rest --method get --url https://graph.microsoft.com/v1.0/directoryRoles/ | jq -r '.value[] | select(.displayName=="Application Administrator").id')
 	minameinrole=$(az rest --method GET --uri "https://graph.microsoft.com/beta/directoryRoles/$appDevRoleId/members" | jq -r '.value[] | select(.displayName | contains("'"$miname"'")).displayName')
 	if [ -z "$minameinrole" ]; then
 		err="Managed Identity is not in Application Administrator role.  Exiting with error."


### PR DESCRIPTION
There are two role id's that gets returned on line 162:
- Application Administrator 
- Cloud Application Administrator

And so line 163 fails with bad request - 400 error. 

The code is now updated to check directly for the role "Application Administrator" role instead of using "contains".