### PR TITLE
Split PurviewTenantId from container TenantId

### DIFF
--- a/Azure-ARM/azuredeploy.json
+++ b/Azure-ARM/azuredeploy.json
@@ -49,6 +49,10 @@
       "defaultValue": "",
       "type": "String"
     },
+    "PurviewTenantId": {
+      "defaultValue": "",
+      "type": "String"      
+    },
     "AlationUrl": {
       "defaultValue": "",
       "type": "String"
@@ -268,6 +272,7 @@
     "PurviewClientId":"[parameters('PurviewClientId')]",
     "PurviewClientSecret":"[parameters('PurviewClientSecret')]",
     "PurviewAccountResourceGroup":"[parameters('PurviewAccountResourceGroup')]",
+    "PurviewTenantId":"[if(and(equals(parameters('UseGovernance'), 'azurePurview'), equals(parameters('PurviewTenantId'), '')), subscription().tenantId, parameters('PurviewTenantId'))]",
     "AlationUrl":"[parameters('AlationUrl')]",
     "AlationUsername":"[parameters('AlationUsername')]",
     "AlationPassword":"[parameters('AlationPassword')]"
@@ -344,6 +349,10 @@
                     {
                         "name": "PURVIEWCLIENTSECRET",
                         "value": "[variables('PurviewClientSecret')]"
+                    },
+                    {
+                        "name": "PURVIEWTENANTID",
+                        "value": "[variables('PurviewTenantId')]"
                     }
                 ]
             }
@@ -841,6 +850,10 @@
                     {
                       "name": "PURVIEWACCOUNTRESOURCEGROUP",
                       "value": "[variables('PurviewAccountResourceGroup')]"
+                    },
+                    {
+                      "name": "PURVIEWTENANTID",
+                      "value": "[variables('PurviewTenantId')]"
                     },
                     {
                       "name": "ALATIONURL",

--- a/Azure-ARM/azuredeploy.parameters.json
+++ b/Azure-ARM/azuredeploy.parameters.json
@@ -38,6 +38,9 @@
         "PurviewClientSecret": {
             "value": ""
         },
+        "PurviewTenantId": {
+            "value": ""
+        },
         "AlationUrl": {
             "value": ""
         },

--- a/Azure-ARM/createUIDefinition.json
+++ b/Azure-ARM/createUIDefinition.json
@@ -351,6 +351,20 @@
             "visible": "[equals(steps('profisee').UseGovernance,'azurePurview')]"
           },
           {
+            "name": "PurviewTenantId",
+            "type": "Microsoft.Common.TextBox",
+            "label": "Purview Tenant ID",
+            "defaultValue": "",
+            "placeholder": "",
+            "toolTip": "If your Purview account is in a different tenant than the one you're deploying Profisee in, please provide the tenant ID of the tenant where Purview is. If Purview is in the same tenant, you can leave this blank.",
+            "constraints": {
+              "required": false,
+              "regex": "",
+              "validationMessage": ""
+            },
+            "visible": "[equals(steps('profisee').UseGovernance,'azurePurview')]"
+          },
+          {
             "name": "AlationUrl",
             "type": "Microsoft.Common.TextBox",
             "label": "Alation URL",
@@ -1124,6 +1138,7 @@
       "PurviewCollectionFriendlyName": "[if(equals(steps('profisee').UseGovernance, 'azurePurview'), steps('profisee').PurviewCollectionFriendlyName, '')]",
       "PurviewClientSecret": "[if(equals(steps('profisee').UseGovernance, 'azurePurview'), steps('profisee').PurviewClientSecret, '')]",
       "PurviewAccountResourceGroup": "[if(equals(steps('profisee').UseGovernance, 'azurePurview'), last(take(split(steps('profisee').PurviewAccountName.id, '/'), 5)), '')]",
+      "PurviewTenantId": "[if(equals(steps('profisee').UseGovernance, 'azurePurview'), steps('profisee').PurviewTenantId, '')]",
       "AlationUrl": "[if(equals(steps('profisee').UseGovernance, 'alation'), steps('profisee').AlationUrl, '')]",
       "AlationUsername": "[if(equals(steps('profisee').UseGovernance, 'alation'), steps('profisee').AlationUsername, '')]",
       "AlationPassword": "[if(equals(steps('profisee').UseGovernance, 'alation'), steps('profisee').AlationPassword, '')]",

--- a/Azure-ARM/deployprofisee.sh
+++ b/Azure-ARM/deployprofisee.sh
@@ -479,7 +479,7 @@ case "$USEGOVERNANCE" in
 		GOVERNANCEPROVIDER="azurePurview"
 		echo "Obtain collection id from provided collection friendly name started.";
 		echo "Grab a token."
-		purviewtoken=$(curl --location --no-progress-meter --request GET "https://login.microsoftonline.com/$TENANTID/oauth2/token" --header 'Content-Type: application/x-www-form-urlencoded' --data-urlencode "client_id=$PURVIEWCLIENTID" --data-urlencode "client_secret=$PURVIEWCLIENTSECRET" --data-urlencode 'grant_type=client_credentials' --data-urlencode 'resource=https://purview.azure.net'  | jq --raw-output '.access_token');
+		purviewtoken=$(curl --location --no-progress-meter --request GET "https://login.microsoftonline.com/$PURVIEWTENANTID/oauth2/token" --header 'Content-Type: application/x-www-form-urlencoded' --data-urlencode "client_id=$PURVIEWCLIENTID" --data-urlencode "client_secret=$PURVIEWCLIENTSECRET" --data-urlencode 'grant_type=client_credentials' --data-urlencode 'resource=https://purview.azure.net'  | jq --raw-output '.access_token');
 		echo "Token acquired."
 		echo "Find collection Id.";
 		echo $"Stripping /catalog from $PURVIEWURL."
@@ -617,7 +617,7 @@ sed -i -e 's/$ACRREPONAME/'"$ACRREPONAME"'/g' Settings.yaml
 sed -i -e 's/$ACRREPOLABEL/'"$ACRREPOLABEL"'/g' Settings.yaml
 sed -i -e 's/$GOVERNANCEPROVIDER/'"$GOVERNANCEPROVIDER"'/g' Settings.yaml
 sed -i -e 's~$PURVIEWURL~'"$PURVIEWURL"'~g' Settings.yaml
-sed -i -e 's/$PURVIEWTENANTID/'"$TENANTID"'/g' Settings.yaml
+sed -i -e 's/$PURVIEWTENANTID/'"$PURVIEWTENANTID"'/g' Settings.yaml
 sed -i -e 's/$PURVIEWCOLLECTIONID/'"$COLLECTIONTRUEID"'/g' Settings.yaml
 sed -i -e 's/$PURVIEWCLIENTID/'"$PURVIEWCLIENTID"'/g' Settings.yaml
 sed -i -e 's/$PURVIEWCLIENTSECRET/'"$PURVIEWCLIENTSECRET"'/g' Settings.yaml

--- a/Azure-ARM/deployprofiseeVariables.txt
+++ b/Azure-ARM/deployprofiseeVariables.txt
@@ -50,6 +50,8 @@ PURVIEWCLIENTID=
 PURVIEWCLIENTSECRET=
 PURVIEWURL=
 PURVIEWCOLLECTIONID=
+#If using Purview and if Purview is in another tenant, then set these
+PURVIEWTENANTID=
 
 #If USEGOVERNANCE=alation, then set these
 ALATIONURL=

--- a/Azure-ARM/prereqcheck.sh
+++ b/Azure-ARM/prereqcheck.sh
@@ -40,6 +40,7 @@ echo $"USEGOVERNANCE is $USEGOVERNANCE"
 echo $"PURVIEWURL is $PURVIEWURL"
 echo $"PURVIEWCOLLECTIONID is $PURVIEWCOLLECTIONID"
 echo $"PURVIEWCLIENTID is $PURVIEWCLIENTID"
+echo $"PURVIEWTENANTID is $PURVIEWTENANTID"
 echo $"ALATIONURL is $ALATIONURL"
 echo $"ALATIONUSERNAME is $ALATIONUSERNAME"
 echo $"TENANTID is $TENANTID"
@@ -137,7 +138,7 @@ if [ "$USEGOVERNANCE" = "azurePurview" ]; then
 	#Check if the provided Purview Collection name exists.
 	#Acquire token
 	echo "Checking if provided Purview collection friendly name exists."
-	purviewtoken=$(curl --location --no-progress-meter --request GET "https://login.microsoftonline.com/$TENANTID/oauth2/token" --header 'Content-Type: application/x-www-form-urlencoded' --data-urlencode "client_id=$PURVIEWCLIENTID" --data-urlencode "client_secret=$PURVIEWCLIENTSECRET" --data-urlencode 'grant_type=client_credentials' --data-urlencode 'resource=https://purview.azure.net' | jq --raw-output '.access_token');
+	purviewtoken=$(curl --location --no-progress-meter --request GET "https://login.microsoftonline.com/$PURVIEWTENANTID/oauth2/token" --header 'Content-Type: application/x-www-form-urlencoded' --data-urlencode "client_id=$PURVIEWCLIENTID" --data-urlencode "client_secret=$PURVIEWCLIENTSECRET" --data-urlencode 'grant_type=client_credentials' --data-urlencode 'resource=https://purview.azure.net' | jq --raw-output '.access_token');
 	#Strip /catalog from end of Purview URL
 	PURVIEWACCOUNTFQDN=${PURVIEWURL::-8}
 	collectionnamenotfound=$(curl --location --no-progress-meter --request GET "$PURVIEWACCOUNTFQDN/account/collections?api-version=2019-11-01-preview" --header "Authorization: Bearer $purviewtoken" | jq --raw-output '.value | .[] | select(.friendlyName=="'$PURVIEWCOLLECTIONID'") | .name');


### PR DESCRIPTION
In order to support scenarios in which Purview is not in the same tenant where the Profisee will be deployed, the ARM template needs to be updated.

The current workaround for supporting this configuration was to not set the Purview settings and then change them in the stateful set to the correct values and bounce the pod.